### PR TITLE
Feature to manage EC2 termination and stop protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,26 +39,32 @@ e2c
 # Start with a specific AWS region
 e2c --region eu-west-1
 
+# Start in expert mode
+e2c --expert-mode
+
 # Show help
 e2c --help
 ```
 
 ## Keyboard Shortcuts
 
-| Key   | Action                               |
-| ----- | ------------------------------------ |
-| `?`   | Help                                 |
-| `q`   | Quit                                 |
-| `Esc` | Back/Close Dialog                    |
-| `f`   | Filter instances                     |
-| `r`   | Refresh                              |
-| `s`   | Start selected instance              |
-| `p`   | Stop selected instance               |
-| `b`   | Reboot selected instance             |
-| `t`   | Terminate selected instance          |
-| `c`   | Connect to selected instance via SSH |
-| `l`   | View instance logs                   |
-| `/`   | Search                               |
+| Key   | Action                                 |
+| ----- | -------------------------------------- |
+| `?`   | Help                                   |
+| `q`   | Quit                                   |
+| `Esc` | Back/Close Dialog                      |
+| `f`   | Filter instances                       |
+| `r`   | Refresh                                |
+| `s`   | Start selected instance                |
+| `p`   | Stop selected instance                 |
+| `b`   | Reboot selected instance               |
+| `t`   | Terminate selected instance            |
+| `c`   | Connect to selected instance via SSH   |
+| `l`   | View instance logs                     |
+| `x`*   | Toggle instance termination protection |
+| `n`*   | Toggle instance stop protection        |
+
+`*` Expert mode only
 
 ## Configuration
 
@@ -76,6 +82,8 @@ aws:
   refresh_interval: 30s
 
 ui:
+  # Expert mode enables termination and stop protection options
+  expert_mode: false
   # Compact mode reduces whitespace in the UI
   compact: false
 ```

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -13,6 +13,9 @@ aws:
   profile: ""
 
 ui:
+  expert_mode: false
+  # Expert mode enables termination and stop protection options
+
   # UI theme (dark or light)
   theme: dark
 

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -13,8 +13,8 @@ aws:
   profile: ""
 
 ui:
-  expert_mode: false
   # Expert mode enables termination and stop protection options
+  expert_mode: false
 
   # UI theme (dark or light)
   theme: dark

--- a/internal/aws/ec2.go
+++ b/internal/aws/ec2.go
@@ -21,11 +21,18 @@ import (
 
 // EC2Client handles interactions with AWS EC2 API
 type EC2Client struct {
-	client     *ec2.Client
-	log        *slog.Logger
-	region     string
-	instancesM sync.Mutex
-	instances  []model.Instance
+	client       *ec2.Client
+	log          *slog.Logger
+	region       string
+	instancesM   sync.Mutex
+	instances    []model.Instance
+	protectionsM sync.RWMutex
+	protections  map[string]protectionStatus
+}
+
+type protectionStatus struct {
+	termination bool
+	stop        bool
 }
 
 // GetRegion returns the current AWS region
@@ -67,14 +74,16 @@ func NewEC2Client(log *slog.Logger, region, profile string) (*EC2Client, error) 
 	client := ec2.NewFromConfig(cfg)
 
 	return &EC2Client{
-		client: client,
-		log:    log,
-		region: region,
+		client:      client,
+		log:         log,
+		region:      region,
+		protections: map[string]protectionStatus{},
 	}, nil
 }
 
-// ListInstances retrieves all EC2 instances in the region
-func (c *EC2Client) ListInstances(ctx context.Context) ([]model.Instance, error) {
+// ListInstances retrieves all EC2 instances in the region. If useCachedProtections is true,
+// cached protection statuses will be included when available without triggering fresh reads.
+func (c *EC2Client) ListInstances(ctx context.Context, useCachedProtections bool) ([]model.Instance, error) {
 	c.log.Info("Listing EC2 instances")
 
 	input := &ec2.DescribeInstancesInput{}
@@ -84,10 +93,16 @@ func (c *EC2Client) ListInstances(ctx context.Context) ([]model.Instance, error)
 	}
 
 	instances := make([]model.Instance, 0)
-
 	for _, reservation := range result.Reservations {
 		for _, instance := range reservation.Instances {
-			i := convertToModelInstance(instance, c.region)
+			instanceID := aws.ToString(instance.InstanceId)
+
+			term, stop, ok := c.getCachedProtection(instanceID)
+			if !useCachedProtections {
+				term, stop, ok = false, false, false
+			}
+
+			i := convertToModelInstance(instance, c.region, term, stop, ok, ok)
 			instances = append(instances, i)
 		}
 	}
@@ -206,19 +221,154 @@ func (c *EC2Client) GetInstanceConsoleOutput(ctx context.Context, instanceID str
 	return *output.Output, nil
 }
 
+// SetTerminationProtection enables or disables termination protection on an instance
+func (c *EC2Client) SetTerminationProtection(ctx context.Context, instanceID string, enabled bool) error {
+	c.log.Info("Updating termination protection", "instanceID", instanceID, "enabled", enabled)
+
+	input := &ec2.ModifyInstanceAttributeInput{
+		InstanceId:            aws.String(instanceID),
+		DisableApiTermination: &types.AttributeBooleanValue{Value: aws.Bool(enabled)},
+	}
+
+	if _, err := c.client.ModifyInstanceAttribute(ctx, input); err != nil {
+		return fmt.Errorf("failed to update termination protection for instance %s: %w", instanceID, err)
+	}
+
+	return nil
+}
+
+// SetStopProtection enables or disables stop protection on an instance
+func (c *EC2Client) SetStopProtection(ctx context.Context, instanceID string, enabled bool) error {
+	c.log.Info("Updating stop protection", "instanceID", instanceID, "enabled", enabled)
+
+	input := &ec2.ModifyInstanceAttributeInput{
+		InstanceId:     aws.String(instanceID),
+		DisableApiStop: &types.AttributeBooleanValue{Value: aws.Bool(enabled)},
+	}
+
+	if _, err := c.client.ModifyInstanceAttribute(ctx, input); err != nil {
+		return fmt.Errorf("failed to update stop protection for instance %s: %w", instanceID, err)
+	}
+
+	return nil
+}
+
+// RefreshProtectionStatus retrieves protections for a single instance, updates the cache, and returns the values.
+func (c *EC2Client) RefreshProtectionStatus(ctx context.Context, instanceID string) (bool, bool, error) {
+	term, stop, err := c.getProtectionAttributes(ctx, instanceID)
+	if err != nil {
+		return false, false, err
+	}
+
+	c.setCachedProtection(instanceID, term, stop)
+
+	return term, stop, nil
+}
+
+// FetchProtectionStatuses fetches protections in the background for the provided instance IDs and streams results.
+func (c *EC2Client) FetchProtectionStatuses(ctx context.Context, instanceIDs []string, workerLimit int) <-chan model.ProtectionStatus {
+	results := make(chan model.ProtectionStatus)
+
+	go func() {
+		defer close(results)
+
+		sem := make(chan struct{}, workerLimit)
+		var wg sync.WaitGroup
+
+		for _, id := range instanceIDs {
+			instanceID := id
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				sem <- struct{}{}
+				termProtection, stopProtection, err := c.getProtectionAttributes(ctx, instanceID)
+				<-sem
+
+				if err != nil {
+					c.log.Warn("Failed to get instance protections", "instanceID", instanceID, "error", err)
+					return
+				}
+
+				results <- model.ProtectionStatus{
+					InstanceID:            instanceID,
+					TerminationProtection: termProtection,
+					StopProtection:        stopProtection,
+				}
+
+				c.setCachedProtection(instanceID, termProtection, stopProtection)
+			}()
+		}
+
+		wg.Wait()
+	}()
+
+	return results
+}
+
+// GetCachedProtectionStatus returns cached protections if available.
+func (c *EC2Client) GetCachedProtectionStatus(instanceID string) (bool, bool, bool) {
+	return c.getCachedProtection(instanceID)
+}
+
+func (c *EC2Client) setCachedProtection(instanceID string, term, stop bool) {
+	c.protectionsM.Lock()
+	c.protections[instanceID] = protectionStatus{termination: term, stop: stop}
+	c.protectionsM.Unlock()
+}
+
+func (c *EC2Client) getCachedProtection(instanceID string) (bool, bool, bool) {
+	c.protectionsM.RLock()
+	defer c.protectionsM.RUnlock()
+
+	protection, ok := c.protections[instanceID]
+	if !ok {
+		return false, false, false
+	}
+
+	return protection.termination, protection.stop, true
+}
+
+func (c *EC2Client) getProtectionAttributes(ctx context.Context, instanceID string) (bool, bool, error) {
+	termAttr, err := c.client.DescribeInstanceAttribute(ctx, &ec2.DescribeInstanceAttributeInput{
+		InstanceId: aws.String(instanceID),
+		Attribute:  types.InstanceAttributeNameDisableApiTermination,
+	})
+	if err != nil {
+		return false, false, fmt.Errorf("failed to describe termination protection: %w", err)
+	}
+
+	stopAttr, err := c.client.DescribeInstanceAttribute(ctx, &ec2.DescribeInstanceAttributeInput{
+		InstanceId: aws.String(instanceID),
+		Attribute:  types.InstanceAttributeNameDisableApiStop,
+	})
+	if err != nil {
+		return false, false, fmt.Errorf("failed to describe stop protection: %w", err)
+	}
+
+	termEnabled := termAttr.DisableApiTermination != nil && termAttr.DisableApiTermination.Value != nil && aws.ToBool(termAttr.DisableApiTermination.Value)
+	stopEnabled := stopAttr.DisableApiStop != nil && stopAttr.DisableApiStop.Value != nil && aws.ToBool(stopAttr.DisableApiStop.Value)
+
+	return termEnabled, stopEnabled, nil
+}
+
 // convertToModelInstance converts an EC2 instance to our internal model
-func convertToModelInstance(instance types.Instance, region string) model.Instance {
+func convertToModelInstance(instance types.Instance, region string, terminationProtection, stopProtection bool, termKnown, stopKnown bool) model.Instance {
 	i := model.Instance{
-		ID:           *instance.InstanceId,
-		Type:         string(instance.InstanceType),
-		State:        string(instance.State.Name),
-		Region:       region,
-		LaunchTime:   aws.ToTime(instance.LaunchTime),
-		PrivateIP:    aws.ToString(instance.PrivateIpAddress),
-		PublicIP:     aws.ToString(instance.PublicIpAddress),
-		Platform:     aws.ToString(instance.PlatformDetails),
-		Architecture: string(instance.Architecture),
-		Tags:         make(map[string]string),
+		ID:                         *instance.InstanceId,
+		Type:                       string(instance.InstanceType),
+		State:                      string(instance.State.Name),
+		Region:                     region,
+		LaunchTime:                 aws.ToTime(instance.LaunchTime),
+		PrivateIP:                  aws.ToString(instance.PrivateIpAddress),
+		PublicIP:                   aws.ToString(instance.PublicIpAddress),
+		Platform:                   aws.ToString(instance.PlatformDetails),
+		Architecture:               string(instance.Architecture),
+		Tags:                       make(map[string]string),
+		TerminationProtection:      terminationProtection,
+		StopProtection:             stopProtection,
+		TerminationProtectionKnown: termKnown,
+		StopProtectionKnown:        stopKnown,
 	}
 
 	// Extract all tags

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -25,6 +25,7 @@ func NewRootCommand(log *slog.Logger) *cobra.Command {
 		region    string
 		logFormat string
 		logLevel  string
+		expert    bool
 	)
 
 	cmd := &cobra.Command{
@@ -64,6 +65,11 @@ across multiple regions.`,
 			// Override with CLI flags
 			cfg.Override(profile, region)
 
+			// Enable expert mode if requested via flag
+			if expert {
+				cfg.UI.ExpertMode = true
+			}
+
 			// Create AWS EC2 client
 			ec2Client, err := aws.NewEC2Client(log, cfg.AWS.DefaultRegion, cfg.AWS.Profile)
 			if err != nil {
@@ -87,6 +93,7 @@ across multiple regions.`,
 	cmd.PersistentFlags().StringVar(&region, "region", "", "AWS region to use")
 	cmd.PersistentFlags().StringVar(&logFormat, "log-format", "", "set log format (json, text)")
 	cmd.PersistentFlags().StringVar(&logLevel, "log-level", "", "set logging level (debug, info, warn, error)")
+	cmd.PersistentFlags().BoolVar(&expert, "expert-mode", false, "enable expert mode features (protection management)")
 
 	// Add version command
 	cmd.AddCommand(newVersionCommand())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,7 +25,8 @@ type AWSConfig struct {
 
 // UIConfig holds UI-specific configuration
 type UIConfig struct {
-	Compact bool `mapstructure:"compact"`
+	Compact    bool `mapstructure:"compact"`
+	ExpertMode bool `mapstructure:"expert_mode"`
 }
 
 // LoadConfig loads the configuration from file and environment variables
@@ -35,7 +36,7 @@ func LoadConfig(log *slog.Logger) (*Config, error) {
 	viper.SetDefault("aws.refresh_interval", "30s")
 	viper.SetDefault("aws.profile", "")
 	viper.SetDefault("ui.compact", false)
-
+	viper.SetDefault("ui.expert_mode", false)
 
 	// Config file name and paths
 	viper.SetConfigName("config")

--- a/internal/model/instance.go
+++ b/internal/model/instance.go
@@ -22,6 +22,18 @@ type Instance struct {
 	Platform     string            // Platform details (e.g., Linux/UNIX, Windows)
 	Architecture string            // Architecture (e.g., x86_64, arm64)
 	Tags         map[string]string // AWS tags associated with the instance
+	// Protection settings
+	TerminationProtection      bool // Whether termination protection is enabled
+	StopProtection             bool // Whether stop protection is enabled
+	TerminationProtectionKnown bool // Whether termination protection has been fetched
+	StopProtectionKnown        bool // Whether stop protection has been fetched
+}
+
+// ProtectionStatus represents the protection attributes of an instance.
+type ProtectionStatus struct {
+	InstanceID            string
+	TerminationProtection bool
+	StopProtection        bool
 }
 
 // GetSSHCommand returns an SSH command for connecting to the instance

--- a/internal/ui/help_view.go
+++ b/internal/ui/help_view.go
@@ -13,11 +13,12 @@ import (
 
 // HelpView represents the help bar at the bottom of the UI
 type HelpView struct {
-	view *tview.TextView
+	view       *tview.TextView
+	expertMode bool
 }
 
 // NewHelpView creates a new help view
-func NewHelpView() *HelpView {
+func NewHelpView(expertMode bool) *HelpView {
 	view := tview.NewTextView().
 		SetDynamicColors(true).
 		SetTextAlign(tview.AlignCenter)
@@ -27,11 +28,15 @@ func NewHelpView() *HelpView {
 
 	// Update help text
 	helpText := "[yellow]?[white]:Help  [yellow]q[white]:Quit  [yellow]r[white]:Refresh  [yellow]f[white]:Filter  [yellow]s[white]:Start  [yellow]p[white]:Stop  [yellow]b[white]:Reboot  [yellow]t[white]:Terminate  [yellow]c[white]:Connect  [yellow]l[white]:Logs"
+	if expertMode {
+		helpText += "  [yellow]x[white]:Term.Protect  [yellow]n[white]:Stop.Protect"
+	}
 
 	view.SetText(helpText)
 
 	return &HelpView{
-		view: view,
+		view:       view,
+		expertMode: expertMode,
 	}
 }
 
@@ -55,14 +60,22 @@ func (h *HelpView) Update(context string) {
 
 	switch context {
 	case "main":
-		h.view.SetText(fmt.Sprintf("[%s]?[%s]:Help [%s]q[%s]:Quit [%s]r[%s]:Refresh [%s]f[%s]:Filter [%s]s[%s]:Start [%s]p[%s]:Stop [%s]b[%s]:Reboot [%s]t[%s]:Terminate [%s]c[%s]:Connect [%s]l[%s]:Logs",
+		mainText := fmt.Sprintf("[%s]?[%s]:Help [%s]q[%s]:Quit [%s]r[%s]:Refresh [%s]f[%s]:Filter [%s]s[%s]:Start [%s]p[%s]:Stop [%s]b[%s]:Reboot [%s]t[%s]:Terminate [%s]c[%s]:Connect [%s]l[%s]:Logs",
 			highlightColor, textColor, highlightColor, textColor, highlightColor, textColor, highlightColor, textColor,
 			highlightColor, textColor, highlightColor, textColor, highlightColor, textColor, highlightColor, textColor,
-			highlightColor, textColor, highlightColor, textColor))
+			highlightColor, textColor, highlightColor, textColor)
+		if h.expertMode {
+			mainText += fmt.Sprintf(" [%s]x[%s]:Term.Protect [%s]n[%s]:Stop.Protect", highlightColor, textColor, highlightColor, textColor)
+		}
+		h.view.SetText(mainText)
 	case "detail":
-		h.view.SetText(fmt.Sprintf("[%s]Esc[%s]:Back [%s]s[%s]:Start [%s]p[%s]:Stop [%s]b[%s]:Reboot [%s]t[%s]:Terminate [%s]c[%s]:Connect [%s]l[%s]:Logs",
+		detailText := fmt.Sprintf("[%s]Esc[%s]:Back [%s]s[%s]:Start [%s]p[%s]:Stop [%s]b[%s]:Reboot [%s]t[%s]:Terminate [%s]c[%s]:Connect [%s]l[%s]:Logs",
 			highlightColor, textColor, highlightColor, textColor, highlightColor, textColor, highlightColor, textColor,
-			highlightColor, textColor, highlightColor, textColor, highlightColor, textColor))
+			highlightColor, textColor, highlightColor, textColor, highlightColor, textColor)
+		if h.expertMode {
+			detailText += fmt.Sprintf(" [%s]x[%s]:Term.Protect [%s]n[%s]:Stop.Protect", highlightColor, textColor, highlightColor, textColor)
+		}
+		h.view.SetText(detailText)
 	case "modal":
 		h.view.SetText(fmt.Sprintf("[%s]Esc[%s]:Close", highlightColor, textColor))
 	default:


### PR DESCRIPTION

     *  show protection states in detail view
     *  add expert-mode flag and UI hints for managing EC2 termination and stop protection
     *  retrieve in background and display protection states in instance listings
     *  provide expert-mode key bindings to toggle protections via EC2 APIs
     *  fix cursor jump issue after refresh
